### PR TITLE
Updated to work with pytorch 0.2.

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -31,7 +31,6 @@ model.eval()
 preds = model(image)
 
 _, preds = preds.max(2)
-preds = preds.squeeze(2)
 preds = preds.transpose(1, 0).contiguous().view(-1)
 
 preds_size = Variable(torch.IntTensor([preds.size(0)]))


### PR DESCRIPTION
demo.py would no longer run with the recent pytorch 0.2. Removed `preds = preds.squeeze(2)` to make it compatible again.

> For pytorch>=0.2, they decided that the .sum(k), .max(k) etc operations would not let an "empty dimension at k" (i.e a dimension k =1). For pytorch<0.2, we needed to do a "squeeze(k), but now the .squeeze(k) has been included in the above operations. That's why it creates a "dimension out of range" because it's trying to do a squeeze(1) on the second dimension, while there's only 1 dimension ("0").